### PR TITLE
Document adding symlinks to load different firmware and fix max volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ SSDT Patch to fix missing speakers sound on Asus Zenbook 14 UX3405MA (2024) and 
 > Added support for **10431A63**
 >
 > https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/sound/pci/hda/cs35l41_hda_property.c?h=v6.11
+> 
+> If the maximum volume is still a bit low in kernel 6.11 and later, you can create the following symlinks to load
+> a different (newer) firmware. Do so at your own risk! 
+>
+> ```
+> cd /lib/firmware/cirrus
+> ln -s cs35l41/v6.83.0/halo_cspl_RAM_revB2_29.85.0.wmfw cs35l41-dsp1-spk-prot-10431a63-spkid0-r0.wmfw
+> ln -s cs35l41/v6.83.0/halo_cspl_RAM_revB2_29.85.0.wmfw cs35l41-dsp1-spk-prot-10431a63-spkid0-l0.wmfw
+> ```
+>
+> Additionally, your linux-firmware package may be missing [this commit with some tunings](https://github.com/CirrusLogic/linux-firmware/commit/dfadf5687922f239eb8b04df0e1726230098b802), add them:
+> ```
+> cd /lib/firmware/cirrus
+> ln -s cs35l41/bincfgs/cs35l41-dsp1-19_5dB.bincfg cs35l41-dsp1-spk-prot-10431a63-spkid0-r0.bincfg
+> ln -s cs35l41/bincfgs/cs35l41-dsp1-19_5dB.bincfg cs35l41-dsp1-spk-prot-10431a63-spkid0-l0.bincfg
+> ```
 
 **BIOS Configuration**
 


### PR DESCRIPTION
I had been looking at my logs with kernel 6.11 and 6.12, it seems it was still loading a generic firmware which didn't engage the amps at full volume:

```
cs35l41-hda spi0-CSC3551:00-cs35l41-hda.0: Falling back to default firmware.
cs35l41-hda spi0-CSC3551:00-cs35l41-hda.0: DSP1: cirrus/cs35l41-dsp1-spk-prot.wmfw: format 3 timestamp 0x62b5c26c
cs35l41-hda spi0-CSC3551:00-cs35l41-hda.0: DSP1: cirrus/cs35l41-dsp1-spk-prot.wmfw: Fri 24 Jun 2022 14:55:56 GMT Daylight Time
cs35l41-hda spi0-CSC3551:00-cs35l41-hda.0: DSP1: Firmware: 400a4 vendor: 0x2 v0.58.0, 2 algorithms
cs35l41-hda spi0-CSC3551:00-cs35l41-hda.0: DSP1: cirrus/cs35l41-dsp1-spk-prot.bin: v0.58.0
``` 

I tried adding a .wmfw symlink to one of the .wmfw files in the `cs35l41` subdirectory (see diff) and it worked, now my max volume is comparable to what you have on Windows. Notice that the firmware version line in the logs changes from v0.58.0 to v0.65.0. Still I'd say this is a bit risky as I have no knowledge of why this works or why it isn't configured like this in the Cirrus linux-firmware source repo. 

```
cs35l41-hda spi0-CSC3551:00-cs35l41-hda.0: DSP1: Firmware: 400a4 vendor: 0x2 v0.65.0, 2 algorithms
cs35l41-hda spi0-CSC3551:00-cs35l41-hda.0: DSP1: cirrus/cs35l41-dsp1-spk-prot-10431a63-spkid0-l0.bin: v0.65.0
cs35l41-hda spi0-CSC3551:00-cs35l41-hda.0: DSP1: spk-prot: C:\Users\tyang\Desktop\Product Setting\SmartAMP\ASUS\ASUS_Zenbook\2023Projects\UX3405MA\Tuning_relea
```   

I also added symlinks to load some tunings according to [this commit](https://github.com/CirrusLogic/linux-firmware/commit/dfadf5687922f239eb8b04df0e1726230098b802)